### PR TITLE
added formatEmpty option to take control over missing translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ gulp.task('taskName', function () {
           suffix: '.suffix',          // output filename suffix, default '.json'
           safeMode: false,            // do not delete old translations, true - contrariwise, default false
           stringifyOptions: true,     // force json to be sorted, false - contrariwise, default false
+          formatEmpty: ""             // define format of the empty message using _.template syntax. Original string is supported using <%=s%>
       }))
       .pipe(gulp.dest(i18ndest));
 });

--- a/index.js
+++ b/index.js
@@ -86,11 +86,17 @@ var customStringify = function (val, stringifyOptions) {
 
 var mergeTranslations = function (results, lang, options) {
     // Create translation object
-    var _translation = new Translations({
-        "safeMode": options.safeMode,
-        "tree": options.tree,
-        "nullEmpty": options.nullEmpty
-      }, results),
+    var _options = {
+      "safeMode": options.safeMode,
+      "tree": options.tree,
+      "formatEmpty": options.formatEmpty
+    };
+    
+    if (options.nullEmpty) { // convert deprecated nullEmpty
+      _options.formatEmpty = null;
+    }
+    
+    var _translation = new Translations(_options, results),
       destFileName = options.dest + '/' + options.prefix + lang + options.suffix,
       isDefaultLang = (options.defaultLang === lang),
       translations = {},
@@ -127,7 +133,8 @@ function extract(options) {
     stringifyOptions: false,
     safeMode: false,    //Translations options
     tree: false,
-    nullEmpty: false
+    nullEmpty: false, // deprecated, overwrites formatEmpty with null when is true
+    formatEmpty: "",
   }, options);
 
   var results = {}, firstFile, 

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -12,7 +12,7 @@
   var translation = new Translations({
     "safeMode": true,
     "tree": true,
-    "nullEmpty": true
+    "formatEmpty": ""
   }, results);
 
   console.log(translation.toString());
@@ -59,7 +59,8 @@ function Translations (params, translations) {
   this.params = _.defaults(params, {
     "tree": false,
     "safeMode": false,
-    "nullEmpty": false
+    "formatEmpty": "",
+    "nullEmpty": false // deprecated: use formatEmpty
   });
   // Set translations if given as parameter
   this.setTranslations(translations);
@@ -93,7 +94,7 @@ Translations.prototype.getMergedTranslations = function (obj, useDefault) {
       if (__isValidTranslation(v)) {
         _returnTranslations[k] = v;
       } else {
-        _returnTranslations[k] = self.params.nullEmpty ? null : "";
+        _returnTranslations[k] = _.template(self.params.formatEmpty)({s: k});
       }
     });
   } else {
@@ -103,8 +104,8 @@ Translations.prototype.getMergedTranslations = function (obj, useDefault) {
         _returnTranslations[k] = obj[k];
       } else if (__isValidTranslation(v)) {   // Get from extracted translations
         _returnTranslations[k] = v;
-      } else {                                // Feed empty translation (null or "")
-        _returnTranslations[k] = self.params.nullEmpty ? null : "";
+      } else {                                // Feed empty translation
+        _returnTranslations[k] = _.template(self.params.formatEmpty)({s: k});
       }
     });
   }
@@ -136,14 +137,14 @@ Translations.prototype.getDefaultTranslations = function (obj) {
 }
 
 /**
- * Format empty translation by using config about nullEmpty (null or "")
+ * Format empty translation
  * @returns {Object}
  */
 Translations.prototype.formatTranslationsEmpty = function () {
   var self = this;
   var _isolatedTranslations = {};
   _.forEach(self._translations, function (v, k) {
-    _isolatedTranslations[k] = (v && v === "" && self.params.nullEmpty ? null : v)
+    _isolatedTranslations[k] = (v && v === "" ? _.template(self.params.formatEmpty)({s: k}) : v)
   });
   return _isolatedTranslations;
 };


### PR DESCRIPTION
added formatEmpty option to take control over missing translations
using _.template() syntax
